### PR TITLE
Adds setup.py configuration for installation via pip etc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+# modules are all .py files starting with a capital letter
+import os
+import re
+
+py_modules = [f[:-3] for f in os.listdir('.')
+              if f.endswith('.py') and re.match(r'^[A-Z]', f)]
+
+setup(
+    name='majoros-utils',
+    version='0.1',
+    py_modules=py_modules,
+    description="Majoros lab utility classes",
+    author="Bill Majoros",
+    author_email='"Bill Majoros" <martiandna@gmail.com>',
+    license="GPL version 3"
+)


### PR DESCRIPTION
This enables including the modules in this repository to be easily included in conda environment specifications or to be installed in a virtual environment via `pip install .`, or by installing from the Git repository.

In this version it enumerates as modules to be installed all .py files starting with a capital letter. Scripts etc in all-lowercase files are therefore not installed, but this could be added where useful. Also, it is probably better then to create a proper package structure.